### PR TITLE
Fix issue with setState warnings in BlogsIndex.jsx

### DIFF
--- a/src/components/BlogsIndex.jsx
+++ b/src/components/BlogsIndex.jsx
@@ -27,12 +27,14 @@ class BlogsIndex extends Component {
         blog['.key'] = childSnap.key;
         blogs.push(blog);
       });
-      if (document.getElementById('blogInd')) {
-        this.setState(() => ({
-          blogs,
-        }));
-      }
+      this.setState(() => ({
+        blogs,
+      }));
     });
+  }
+
+  componentWillUnmount() {
+    blogsRef.off();
   }
 
   onDelete(key) {
@@ -42,10 +44,12 @@ class BlogsIndex extends Component {
         modalOpen: false,
       });
       setTimeout(() => {
-        this.setState({
-          msg: false,
-          deleteKey: null,
-        });
+        if (this.componentRef) {
+          this.setState({
+            msg: false,
+            deleteKey: null,
+          });
+        }
       }, 2000);
     });
   }
@@ -71,11 +75,11 @@ class BlogsIndex extends Component {
           </td>
           <td className="blogInd__cell blogInd__imgCont">
             {blog.images && blog.images.featured &&
-            <img
-              className="blogInd__thumb"
-              src={resize(50, blog.images.featured.url)}
-              alt={blog.images.featured.alt}
-            /> }
+              <img
+                className="blogInd__thumb"
+                src={resize(50, blog.images.featured.url)}
+                alt={blog.images.featured.alt}
+              />}
           </td>
           <td className="blogInd__cell blogInd__meta">{formatDate(new Date(blog.timestamp))}</td>
           <td className="blogInd__cell blogInd__icon-container">
@@ -139,23 +143,24 @@ class BlogsIndex extends Component {
           </div>
         </Modal>
         {this.state.msg && <div className="blogInd__message">The post was successfully deleted.</div>}
-        { (!blogsArr.length) ? <Loading /> :
-        <div className="blogInd__table-cont">
-          <table className="blogInd__grid">
-            <thead>
-              <tr>
-                <th className="blogInd__tableHead">Title</th>
-                <th className="blogInd__tableHead">Image</th>
-                <th className="blogInd__tableHead">Date</th>
-                <th className="blogInd__tableHead">Edit</th>
-                <th className="blogInd__tableHead">Delete</th>
-              </tr>
-            </thead>
-            <tbody>
-              {blogsArr.reverse()}
-            </tbody>
-          </table>
-        </div>}
+        {(!blogsArr.length)
+          ? <Loading />
+          : <div ref={(ref) => { this.componentRef = ref; }} className="blogInd__table-cont">
+            <table className="blogInd__grid">
+              <thead>
+                <tr>
+                  <th className="blogInd__tableHead">Title</th>
+                  <th className="blogInd__tableHead">Image</th>
+                  <th className="blogInd__tableHead">Date</th>
+                  <th className="blogInd__tableHead">Edit</th>
+                  <th className="blogInd__tableHead">Delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                {blogsArr.reverse()}
+              </tbody>
+            </table>
+          </div>}
       </div>
     );
   }


### PR DESCRIPTION
There were two separate issues with the setState warning.

`blogsRef` still had it’s event listeners attached even after the component unmounted. Since blogsRef is outside the scope of that particular instance, it was still alive and called `this.setState()` with `this` pointing to the unmounted component.

calling `blogsRef.off()` from within `componentWillUnmount()` removes all of it’s event listeners.

The other issue that was occurring was when deleting a post and then navigating to a different view before the following callback was executed:
```
setTimeout(() => {
        this.setState({
          msg: false,
          deleteKey: null,
        });
      }, 2000);
```

Checking against a reference to the component before calling setState seems to fix this issue. The reference is against the grid <div> called here: `<div ref={(ref) => { this.componentRef = ref; }} className="blogInd__table-cont">`

Code now looks like this:
```
setTimeout(() => {
        if (this.componentRef) {
          this.setState({
            msg: false,
            deleteKey: null,
          });
        }
      }, 2000);
```