### PR TITLE
Gallery index section

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -19,6 +19,7 @@ import SinglePostDisplay from './SinglePostDisplay';
 import Notizie from './Notizie';
 import Dashboard from './Dashboard';
 import CreatePhotoGallery from './CreatePhotoGallery';
+import GalleryIndex from './GalleryIndex';
 
 import { saveAuth } from '../actions';
 
@@ -58,6 +59,7 @@ class App extends Component {
 
             {this.props.auth && <Route path="/createblog" component={CreateBlog} />}
             {this.props.auth && <Route path="/createphotogallery" component={CreatePhotoGallery} />}
+            {this.props.auth && <Route path="/galleryindex" component={GalleryIndex} />}
             {this.props.auth && <Route path="/updatestats" component={UpdateStats} />}
             {this.props.auth && <Route path="/dashboard" component={Dashboard} />}
             {this.props.auth && <Route path="/edit/:key" component={CreateBlog} />}

--- a/src/components/BlogsIndex.jsx
+++ b/src/components/BlogsIndex.jsx
@@ -71,34 +71,37 @@ class BlogsIndex extends Component {
         accessor: 'title',
         minWidth: 160,
         Cell: props =>
-        <div className="blogInd__cell">
-          <Link className="blogInd__title" to={`/blog/${props.original.slug}`}>{props.original.title}</Link> </div> },
+          <div className="blogInd__cell">
+            <Link className="blogInd__title" to={`/blog/${props.original.slug}`}>{props.original.title}</Link> </div> },
       { Header: () => <div className="blogInd__tableHead">Image</div>,
         accessor: 'image',
         minWidth: 30,
         filterable: false,
         Cell: props =>
-        <div className="blogInd__cell center">
-          <img
-            className="blogInd__thumb"
-            src={resize(50, props.original.images.featured.url)}
-            alt={props.original.images.featured.alt}
-          /> </div>},
+          <div className="blogInd__cell center">
+            <img
+              className="blogInd__thumb"
+              src={resize(50, props.original.images.featured.url)}
+              alt={props.original.images.featured.alt}
+            /> </div> },
       { Header: () => <div className="blogInd__tableHead">Date</div>,
-        accessor: 'date', minWidth: 60, filterable: false, Cell: props => <div className="blogInd__cell center"> {formatDate(new Date(props.original.timestamp))}</div>,
+        accessor: 'date',
+        minWidth: 60,
+        filterable: false,
+        Cell: props => <div className="blogInd__cell center"> {formatDate(new Date(props.original.timestamp))}</div>,
       },
       { Header: () => <div className="blogInd__tableHead">Edit</div>,
         accessor: 'edit',
         minWidth: 40,
         filterable: false,
         Cell: props =>
-        <div className="blogInd__cell center">
-          <Link
-            to={`/edit/${props.original.key}`}
-            className=""
-          >
-            <div className="blogInd__icon blogInd__icon--edit" />
-          </Link> </div>},
+          <div className="blogInd__cell center">
+            <Link
+              to={`/edit/${props.original.key}`}
+              className=""
+            >
+              <div className="blogInd__icon blogInd__icon--edit" />
+            </Link> </div> },
       { Header: () => <div className="blogInd__tableHead">Delete</div>,
         accessor: 'delete',
         minWidth: 40,

--- a/src/components/CreatePhotoGallery.jsx
+++ b/src/components/CreatePhotoGallery.jsx
@@ -166,7 +166,6 @@ class CreatePhotoGallery extends Component {
 
   handleSubmit(e) {
     e.preventDefault();
-
     // Prevent submit when no images have been selected for upload
     if (this.state.images.length === 0) {
       this.displayMainError('Gallery cannot be empty');
@@ -197,20 +196,19 @@ class CreatePhotoGallery extends Component {
       }
 
       // VALIDATION OK: BEGIN UPLOAD PRCOCESS
+      const newGalleryKey = galleriesRef.push().key;
+
       this.setState({ uploading: true });
       const files = this.state.images;
       const storageRef = firebase.storage().ref();
-      const dateStamp = Date.now();
-
       const dbEntry = {
         images: [],
         title: this.state.galleryName,
         timestamp: timeRef,
         slug: generateSlug(this.state.galleryName),
+        key: newGalleryKey,
       };
       const uploads = files.map((file) => {
-        // TODO: figure out a better way to handle unique ids
-
         const metaData = {
           customMetadata: {
             altText: this.state[file.name],
@@ -219,8 +217,7 @@ class CreatePhotoGallery extends Component {
 
         const task = storageRef
           .child(
-          `images/galleries/${this.state
-            .galleryName} (${dateStamp})/${file.name}`,
+          `images/galleries/${newGalleryKey}/${file.name}`,
         )
           .put(file, metaData);
 
@@ -250,7 +247,7 @@ class CreatePhotoGallery extends Component {
 
       Promise.all(uploads).then(() => {
         galleriesRef
-          .child(`${this.state.galleryName}/`)
+          .child(newGalleryKey)
           .set(dbEntry)
           .then(() => {
             this.props.history.push('/dashboard');

--- a/src/components/CreatePhotoGallery.jsx
+++ b/src/components/CreatePhotoGallery.jsx
@@ -1,3 +1,4 @@
+// TODO: Create featured/cover image selection
 import React, { Component } from 'react';
 import Dropzone from 'react-dropzone';
 import * as firebase from 'firebase';

--- a/src/components/CreatePhotoGallery.jsx
+++ b/src/components/CreatePhotoGallery.jsx
@@ -3,7 +3,14 @@ import Dropzone from 'react-dropzone';
 import * as firebase from 'firebase';
 import FormInput from './FormInput';
 import ErrorMessages from './ErrorMessages';
-import { fieldValidationsPhotoGallery, run, ruleRunner, required } from '../utils/index';
+import {
+  fieldValidationsPhotoGallery,
+  run,
+  ruleRunner,
+  required,
+  timeRef,
+  generateSlug,
+} from '../utils/index';
 
 const PreviewGrid = require('react-packery-component')(React);
 
@@ -53,7 +60,11 @@ class CreatePhotoGallery extends Component {
 
   onImageDrop(files) {
     // check to ensure file names are unique
-    if (files.some(file => this.state.images.some(image => image.name === file.name))) {
+    if (
+      files.some(file =>
+        this.state.images.some(image => image.name === file.name),
+      )
+    ) {
       this.displayMainError('File names must be unique');
       return;
     }
@@ -64,7 +75,10 @@ class CreatePhotoGallery extends Component {
 
       this.setState({
         images: [...this.state.images, ...files],
-        validationErrors: run({ ...this.state }, this.state.localFieldValidations),
+        validationErrors: run(
+          { ...this.state },
+          this.state.localFieldValidations,
+        ),
       });
     });
   }
@@ -95,7 +109,10 @@ class CreatePhotoGallery extends Component {
   handleBlur(e) {
     const field = e.target.name;
     const newState = {
-      validationErrors: run({ ...this.state }, this.state.localFieldValidations),
+      validationErrors: run(
+        { ...this.state },
+        this.state.localFieldValidations,
+      ),
       showErrors: { ...this.state.showErrors, [field]: true },
       touched: { ...this.state.touched, [field]: true },
     };
@@ -105,7 +122,10 @@ class CreatePhotoGallery extends Component {
   handleFocus(e) {
     const field = e.target.name;
     const newState = {
-      validationErrors: run({ ...this.state }, this.state.localFieldValidations),
+      validationErrors: run(
+        { ...this.state },
+        this.state.localFieldValidations,
+      ),
       showErrors: { ...this.state.showErrors, [field]: false },
       touched: { ...this.state.touched, [field]: false },
     };
@@ -122,7 +142,10 @@ class CreatePhotoGallery extends Component {
     } else {
       files[fileIndex][fileName] = snap.bytesTransferred;
     }
-    const bytesTransferred = files.reduce((total, file) => total + Object.values(file)[0], 0);
+    const bytesTransferred = files.reduce(
+      (total, file) => total + Object.values(file)[0],
+      0,
+    );
     this.setState({
       uploadProgress: {
         totalBytes,
@@ -153,90 +176,106 @@ class CreatePhotoGallery extends Component {
     const newState = {
       ...this.state,
       ...{
-        validationErrors: run({ ...this.state }, this.state.localFieldValidations),
+        validationErrors: run(
+          { ...this.state },
+          this.state.localFieldValidations,
+        ),
         showErrors: { galleryName: true },
         submit: true,
       },
     };
-    this.state.images.forEach((image) => { newState.showErrors[image.name] = true; });
+    this.state.images.forEach((image) => {
+      newState.showErrors[image.name] = true;
+    });
 
-    Object.keys(newState.touched).forEach((key) => { newState.touched[key] = true; });
-    this.setState(
-      { ...this.state, ...newState }, () => {
-        if (Object.keys(this.state.validationErrors).length > 0) {
-          return;
-        }
+    Object.keys(newState.touched).forEach((key) => {
+      newState.touched[key] = true;
+    });
+    this.setState({ ...this.state, ...newState }, () => {
+      if (Object.keys(this.state.validationErrors).length > 0) {
+        return;
+      }
 
-        // VALIDATION OK: BEGIN UPLOAD PRCOCESS
-        this.setState({ uploading: true });
-        const files = this.state.images;
-        const storageRef = firebase.storage().ref();
-        const dateStamp = Date.now();
+      // VALIDATION OK: BEGIN UPLOAD PRCOCESS
+      this.setState({ uploading: true });
+      const files = this.state.images;
+      const storageRef = firebase.storage().ref();
+      const dateStamp = Date.now();
 
-        const dbEntry = [];
-        const uploads = files.map((file) => {
-          // TODO: figure out a better way to handle unique ids
+      const dbEntry = {
+        images: [],
+        title: this.state.galleryName,
+        timestamp: timeRef,
+        slug: generateSlug(this.state.galleryName),
+      };
+      const uploads = files.map((file) => {
+        // TODO: figure out a better way to handle unique ids
 
-          const metaData = {
-            customMetadata: {
-              altText: this.state[file.name],
+        const metaData = {
+          customMetadata: {
+            altText: this.state[file.name],
+          },
+        };
+
+        const task = storageRef
+          .child(
+          `images/galleries/${this.state
+            .galleryName} (${dateStamp})/${file.name}`,
+        )
+          .put(file, metaData);
+
+        return new Promise((resolve, reject) => {
+          task.on(
+            'state_changed',
+            (snap) => {
+              this._updateProgress(snap, file.name);
             },
-          };
-
-          const task = storageRef
-            .child(
-            `images/galleries/${this.state
-              .galleryName} (${dateStamp})/${file.name}`,
-          )
-            .put(file, metaData);
-
-          return new Promise((resolve, reject) => {
-            task.on(
-              'state_changed',
-              (snap) => {
-                this._updateProgress(snap, file.name);
-              },
-              (err) => {
-                console.log(err);
-                reject();
-              },
-              () => {
-                dbEntry.push({
-                  fileName: file.name,
-                  fileUrl: task.snapshot.downloadURL,
-                  altText: this.state[file.name],
-                });
-                resolve();
-              },
-            );
-          })
-            .catch((err) => {
-              console.error(err);
-            });
-        });
-
-        Promise.all(uploads).then(() => {
-          galleriesRef.child(`${this.state.galleryName}/`)
-            .set(dbEntry)
-            .then(() => {
-              this.props.history.push('/dashboard');
-            });
+            (err) => {
+              console.log(err);
+              reject();
+            },
+            () => {
+              dbEntry.images.push({
+                fileName: file.name,
+                url: task.snapshot.downloadURL,
+                alt: this.state[file.name],
+              });
+              resolve();
+            },
+          );
+        }).catch((err) => {
+          console.error(err);
         });
       });
+
+      Promise.all(uploads).then(() => {
+        galleriesRef
+          .child(`${this.state.galleryName}/`)
+          .set(dbEntry)
+          .then(() => {
+            this.props.history.push('/dashboard');
+          });
+      });
+    });
   }
 
   removeFile(e) {
     const fileName = e.target.name;
 
-    this.setState({
-      images: this.state.images.filter(img => img.name !== fileName),
-    }, () => {
-      // reset field validations
-      this.setState({ localFieldValidations: [...fieldValidationsPhotoGallery] });
-      this.state.images.forEach((file) => {
-        this.createFieldValidations(file);
-      });
-    });
+    this.setState(
+      {
+        images: this.state.images.filter(img => img.name !== fileName),
+      },
+      () => {
+        // reset field validations
+        this.setState({
+          localFieldValidations: [...fieldValidationsPhotoGallery],
+        });
+        this.state.images.forEach((file) => {
+          this.createFieldValidations(file);
+        });
+      },
+    );
   }
 
   unsavedChanges(e) {
@@ -250,7 +289,11 @@ class CreatePhotoGallery extends Component {
   render() {
     let dropzoneRef;
     return (
-      <div ref={(ref) => { this.componentRef = ref; }}>
+      <div
+        ref={(ref) => {
+          this.componentRef = ref;
+        }}
+      >
         <h2>Create a new photo gallery</h2>
         <div className="newBlog__container">
           <form className="newBlog__form">
@@ -268,7 +311,9 @@ class CreatePhotoGallery extends Component {
             />
             <ErrorMessages display={!!this.state.mainErrorDisplay}>
               <div className="form__error-wrap">
-                <span className="form__error-content">{this.state.mainErrorDisplay}</span>
+                <span className="form__error-content">
+                  {this.state.mainErrorDisplay}
+                </span>
               </div>
             </ErrorMessages>
             <Dropzone
@@ -320,14 +365,16 @@ class CreatePhotoGallery extends Component {
             </div>
             {this.state.uploadProgress.percentProgress > 0 &&
               <span className="newBlog__imgProg">
-                <span className="newBlog__img-upload-progress">Uploading... {this.state.uploadProgress.percentProgress}%</span>
+                <span className="newBlog__img-upload-progress">
+                  Uploading... {this.state.uploadProgress.percentProgress}%
+                </span>
               </span>}
           </form>
           <div className="newBlog__preview createGallery__preview">
             <h3 className="newBlog__subhead">Preview</h3>
             <div className="newBlog__wrapper">
               <PreviewGrid options={packeryOptions}>
-                {this.state.images.map(file => (
+                {this.state.images.map(file =>
                   <div key={file.preview} className="preview-item">
                     <div className="image-container">
                       <div>
@@ -343,7 +390,11 @@ class CreatePhotoGallery extends Component {
                         className="form__input"
                         type="text"
                         name={file.name}
-                        value={this.state.images.find(item => item.name === file.name).altText}
+                        value={
+                          this.state.images.find(
+                            item => item.name === file.name,
+                          ).altText
+                        }
                         placeholder="Alt text for image"
                         handleChange={this.handleChange}
                         handleBlur={this.handleBlur}
@@ -362,10 +413,10 @@ class CreatePhotoGallery extends Component {
                         onClick={this.removeFile}
                       >
                         Remove
-                    </a>
+                      </a>
                     </div>
-                  </div>
-                ))}
+                  </div>,
+                )}
               </PreviewGrid>
             </div>
           </div>

--- a/src/components/CreatePhotoGallery.jsx
+++ b/src/components/CreatePhotoGallery.jsx
@@ -250,7 +250,7 @@ class CreatePhotoGallery extends Component {
           .child(newGalleryKey)
           .set(dbEntry)
           .then(() => {
-            this.props.history.push('/dashboard');
+            this.props.history.push('/galleryindex');
           });
       });
     });

--- a/src/components/CreatePhotoGallery.jsx
+++ b/src/components/CreatePhotoGallery.jsx
@@ -1,6 +1,7 @@
 // TODO: Create featured/cover image selection
 import React, { Component } from 'react';
 import Dropzone from 'react-dropzone';
+import { Link } from 'react-router-dom';
 import * as firebase from 'firebase';
 import FormInput from './FormInput';
 import ErrorMessages from './ErrorMessages';
@@ -352,6 +353,7 @@ class CreatePhotoGallery extends Component {
               >
                 Choose File
               </a>
+              <br />
               <a
                 role="button"
                 tabIndex="0"
@@ -360,6 +362,10 @@ class CreatePhotoGallery extends Component {
               >
                 {!this.state.uploading ? 'Upload Gallery' : 'Uploading'}
               </a>
+              <Link
+                to="/galleryindex"
+                className="newBlog__cancel newBlog__button"
+              >Cancel</Link>
             </div>
             {this.state.uploadProgress.percentProgress > 0 &&
               <span className="newBlog__imgProg">

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -22,8 +22,8 @@ class Dashboard extends Component {
           <Link to="/updatestats" className="dash__button">
             Update Statistics
           </Link>
-          <Link to="/createphotogallery" className="dash__button">
-            New Photo Gallery
+          <Link to="/galleryindex" className="dash__button">
+            Photo Galleries
           </Link>
         </div>
         <div className="blog__container">

--- a/src/components/GalleryIndex.jsx
+++ b/src/components/GalleryIndex.jsx
@@ -126,25 +126,25 @@ class GalleryIndex extends Component {
     ];
 
     const { galleries } = this.state;
-    let galleriesArr = [];
-    if (galleries.length) {
-      galleriesArr = galleries.map(gallery => (
-        <tr key={gallery['.key']} className="blogInd__row" >
-          <td className="blogInd__cell blogInd__title">
-            <Link to={`/gallery/${gallery.slug}`}>
-              {gallery.title}
-            </Link>
-          </td>
-          <td className="galleryInd__cell galleryInd__imgCont">
-            {gallery.images &&
-              <img
-                className="galleryInd__thumb"
-                src={resize(50, gallery.images[0].url)}
-                alt={gallery.images[0].alt}
-              />}
-          </td>
-        </tr>));
-    }
+    // let galleriesArr = [];
+    // if (galleries.length) {
+    //   galleriesArr = galleries.map(gallery => (
+    //     <tr key={gallery['.key']} className="blogInd__row" >
+    //       <td className="blogInd__cell blogInd__title">
+    //         <Link to={`/gallery/${gallery.slug}`}>
+    //           {gallery.title}
+    //         </Link>
+    //       </td>
+    //       <td className="galleryInd__cell galleryInd__imgCont">
+    //         {gallery.images &&
+    //           <img
+    //             className="galleryInd__thumb"
+    //             src={resize(50, gallery.images[0].url)}
+    //             alt={gallery.images[0].alt}
+    //           />}
+    //       </td>
+    //     </tr>));
+    // }
     // TODO: add styling to <div>
     let noDataPlaceholder = <Loading />;
     if (!this.state.galleriesExistInDb) {
@@ -202,7 +202,7 @@ class GalleryIndex extends Component {
           </Link>
           </div>
         </div>
-        {galleriesArr.length === 0
+        {galleries.length === 0
           ? noDataPlaceholder
           : <div ref={(ref) => { this.componentRef = ref; }} className="blogInd__table-cont">
             <ReactTable
@@ -210,7 +210,6 @@ class GalleryIndex extends Component {
               data={galleries}
               columns={tableColumns}
               defaultPageSize={5}
-              filterable
               defaultFilterMethod={(filter, row) =>
                 row[filter.id].includes(filter.value)}
             />

--- a/src/components/GalleryIndex.jsx
+++ b/src/components/GalleryIndex.jsx
@@ -15,6 +15,7 @@ class GalleryIndex extends Component {
       msg: false,
       // currentKey: '',
       modalOpen: false,
+      galleriesExistInDb: false,
       // filterQuery: '',
     };
     this.openModal = this.openModal.bind(this);
@@ -23,6 +24,9 @@ class GalleryIndex extends Component {
 
   componentDidMount() {
     galleriesRef.on('value', (snap) => {
+      this.setState({
+        galleriesExistInDb: !!snap.val(),
+      });
       const galleries = [];
 
       snap.forEach((childSnap) => {
@@ -141,7 +145,12 @@ class GalleryIndex extends Component {
           </td>
         </tr>));
     }
-
+    // TODO: add styling to <div>
+    let noDataPlaceholder = <Loading />;
+    if (!this.state.galleriesExistInDb) {
+      noDataPlaceholder = <div>There are no galleries to display</div>;
+    }
+    // NOTE: Cover image shown should be controllable
     return (
       <div>
         <Modal
@@ -193,8 +202,8 @@ class GalleryIndex extends Component {
           </Link>
           </div>
         </div>
-        {(!galleriesArr.length)
-          ? <Loading />
+        {galleriesArr.length === 0
+          ? noDataPlaceholder
           : <div ref={(ref) => { this.componentRef = ref; }} className="blogInd__table-cont">
             <ReactTable
               className="blogInd__grid -striped"

--- a/src/components/GalleryIndex.jsx
+++ b/src/components/GalleryIndex.jsx
@@ -97,6 +97,7 @@ class GalleryIndex extends Component {
         accessor: 'date',
         minWidth: 60,
         filterable: false,
+        defaultSortDesc: true,
         Cell: props => <div className="blogInd__cell center"> {formatDate(new Date(props.original.timestamp))}</div>,
       },
       {
@@ -125,7 +126,7 @@ class GalleryIndex extends Component {
       },
     ];
 
-    const { galleries } = this.state;
+    const galleries = [...this.state.galleries].reverse();
     // let galleriesArr = [];
     // if (galleries.length) {
     //   galleriesArr = galleries.map(gallery => (

--- a/src/components/GalleryIndex.jsx
+++ b/src/components/GalleryIndex.jsx
@@ -185,6 +185,14 @@ class GalleryIndex extends Component {
             </div>
           </div>
         </Modal>
+        <div className="dash__container">
+          <h2 className="dash__banner">Dashboard</h2>
+          <div className="dash__buttons-cont">
+            <Link to="/createphotogallery" className="dash__button">
+              Create New Photo Gallery
+          </Link>
+          </div>
+        </div>
         {(!galleriesArr.length)
           ? <Loading />
           : <div ref={(ref) => { this.componentRef = ref; }} className="blogInd__table-cont">

--- a/src/components/GalleryIndex.jsx
+++ b/src/components/GalleryIndex.jsx
@@ -39,7 +39,7 @@ class GalleryIndex extends Component {
   componentWillUnmount() {
     galleriesRef.off();
   }
-
+  // TODO: Delete photos in storage as well
   onDelete(key) {
     galleriesRef.child(key).remove().then(() => {
       this.setState({

--- a/src/components/GalleryIndex.jsx
+++ b/src/components/GalleryIndex.jsx
@@ -40,6 +40,23 @@ class GalleryIndex extends Component {
     galleriesRef.off();
   }
 
+  onDelete(key) {
+    galleriesRef.child(key).remove().then(() => {
+      this.setState({
+        msg: true,
+        modalOpen: false,
+      });
+      setTimeout(() => {
+        if (this.componentRef) {
+          this.setState({
+            msg: false,
+            deleteKey: null,
+          });
+        }
+      }, 2000);
+    });
+  }
+
   closeModal() {
     this.setState(() => ({ modalOpen: false }));
   }
@@ -77,6 +94,30 @@ class GalleryIndex extends Component {
         minWidth: 60,
         filterable: false,
         Cell: props => <div className="blogInd__cell center"> {formatDate(new Date(props.original.timestamp))}</div>,
+      },
+      {
+        Header: () => <div className="blogInd__tableHead">Edit</div>,
+        accessor: 'edit',
+        minWidth: 40,
+        filterable: false,
+        Cell: props =>
+          <div className="blogInd__cell center">
+            <Link
+              to={`/edit-gallery/${props.original.slug}`}
+              className=""
+            >
+              <div className="blogInd__icon blogInd__icon--edit" />
+            </Link></div>,
+      },
+      {
+        Header: () => <div className="blogInd__tableHead">Delete</div>,
+        accessor: 'delete',
+        minWidth: 40,
+        filterable: false,
+        Cell: props => <div className="blogInd__cell center"> <button
+          className="blogInd__icon blogInd__icon--delete"
+          onClick={() => this.openModal(props.original['.key'])}
+        /></div>,
       },
     ];
 

--- a/src/components/GalleryIndex.jsx
+++ b/src/components/GalleryIndex.jsx
@@ -103,7 +103,7 @@ class GalleryIndex extends Component {
         Cell: props =>
           <div className="blogInd__cell center">
             <Link
-              to={`/edit-gallery/${props.original.slug}`}
+              to={`/edit-gallery/${props.original.key}`}
               className=""
             >
               <div className="blogInd__icon blogInd__icon--edit" />

--- a/src/components/GalleryIndex.jsx
+++ b/src/components/GalleryIndex.jsx
@@ -1,0 +1,164 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import Modal from 'react-modal';
+import ReactTable from 'react-table';
+import 'react-table/react-table.css';
+
+import { formatDate, resize, galleriesRef } from '../utils/';
+import Loading from './Loading';
+
+class GalleryIndex extends Component {
+  constructor() {
+    super();
+    this.state = {
+      galleries: [],
+      msg: false,
+      // currentKey: '',
+      modalOpen: false,
+      // filterQuery: '',
+    };
+    this.openModal = this.openModal.bind(this);
+    this.closeModal = this.closeModal.bind(this);
+  }
+
+  componentDidMount() {
+    galleriesRef.on('value', (snap) => {
+      const galleries = [];
+
+      snap.forEach((childSnap) => {
+        const gallery = childSnap.val();
+        gallery['.key'] = childSnap.key;
+        galleries.push(gallery);
+      });
+      this.setState(() => ({
+        galleries,
+      }));
+    });
+  }
+
+  componentWillUnmount() {
+    galleriesRef.off();
+  }
+
+  closeModal() {
+    this.setState(() => ({ modalOpen: false }));
+  }
+
+  openModal(key) {
+    this.setState(() => ({ modalOpen: true, deleteKey: key }));
+  }
+
+  render() {
+    const tableColumns = [
+      {
+        Header: () => <div className="blogInd__tableHead">Title</div>,
+        accessor: 'title',
+        minWidth: 160,
+        Cell: props =>
+          <div className="blogInd__cell">
+            <Link className="blogInd__title" to={`/gallery/${props.original.slug}`}>{props.original.title}</Link></div>,
+      },
+      {
+        Header: () => <div className="blogInd__tableHead">Cover Image</div>,
+        accessor: 'image',
+        minWidth: 30,
+        filterable: false,
+        Cell: props =>
+          <div className="blogInd__cell center">
+            <img
+              className="blogInd__thumb"
+              src={resize(50, props.original.images[0].url)}
+              alt={props.original.images[0].alt}
+            /> </div>,
+      },
+      {
+        Header: () => <div className="blogInd__tableHead">Date</div>,
+        accessor: 'date',
+        minWidth: 60,
+        filterable: false,
+        Cell: props => <div className="blogInd__cell center"> {formatDate(new Date(props.original.timestamp))}</div>,
+      },
+    ];
+
+    const { galleries } = this.state;
+    let galleriesArr = [];
+    if (galleries.length) {
+      galleriesArr = galleries.map(gallery => (
+        <tr key={gallery['.key']} className="blogInd__row" >
+          <td className="blogInd__cell blogInd__title">
+            <Link to={`/gallery/${gallery.slug}`}>
+              {gallery.title}
+            </Link>
+          </td>
+          <td className="galleryInd__cell galleryInd__imgCont">
+            {gallery.images &&
+              <img
+                className="galleryInd__thumb"
+                src={resize(50, gallery.images[0].url)}
+                alt={gallery.images[0].alt}
+              />}
+          </td>
+        </tr>));
+    }
+
+    return (
+      <div>
+        <Modal
+          isOpen={this.state.modalOpen}
+          onAfterOpen={this.afterOpenModal}
+          onRequestClose={this.closeModal}
+          className="modal"
+          contentLabel="Confirm Delete"
+        >
+          <div className="modal__dialog">
+            <div className="modal__content">
+              <div className="modal__header">
+                <button
+                  type="button"
+                  onClick={this.closeModal}
+                  className="modal__close--x"
+                  data-dismiss="modal"
+                  aria-label="Close"
+                >
+                  <span aria-hidden="true">×</span>
+                </button>
+                <h2 className="modal__title" id="modalTitle">Confirm Delete</h2>
+              </div>
+              <div className="modal__body">
+                <p>Are you sure you want to delete this post? This cannot be undone.</p>
+              </div>
+              <div className="modal__footer">
+                <button
+                  type="button"
+                  onClick={this.closeModal}
+                  className="modal__button modal__close--btn"
+                  data-dismiss="modal"
+                >Cancel</button>
+                <button
+                  type="button"
+                  onClick={() => this.onDelete(this.state.deleteKey)}
+                  className="modal__button modal__confirm"
+                  data-dismiss="modal"
+                >Delete</button>
+              </div>
+            </div>
+          </div>
+        </Modal>
+        {(!galleriesArr.length)
+          ? <Loading />
+          : <div ref={(ref) => { this.componentRef = ref; }} className="blogInd__table-cont">
+            <ReactTable
+              className="blogInd__grid -striped"
+              data={galleries}
+              columns={tableColumns}
+              defaultPageSize={5}
+              filterable
+              defaultFilterMethod={(filter, row) =>
+                row[filter.id].includes(filter.value)}
+            />
+          </div>}
+      </div>
+    );
+  }
+}
+export default GalleryIndex;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -17,6 +17,7 @@ firebase.initializeApp(config);
 
 export const rootRef = firebase.database().ref().child('avis');
 export const blogsRef = rootRef.child('blogs');
+export const galleriesRef = rootRef.child('galleries');
 export const timeRef = firebase.database.ServerValue.TIMESTAMP;
 
 // //////////// BLOG POST CREATE FUNCTIONS /////////////////


### PR DESCRIPTION
The beginnings of the gallery index section. It functions very similarly to the blogs index. 

- The gallery index can be reached via a link on the dashboard. 
- Creating a new gallery is now done via a link on the gallery index page. 
- I changed how the entries were stored in the database and storage, using the entry's Firebase key instead of the entry's title in order to align with how blogs are currently saved.

Other things to note:
- At the moment, deleting a gallery from the index only deletes the database entry, not the photos stored in storage.
- I am still working on a reliable way to allow the user to select the cover/featured image